### PR TITLE
Add Carmen.Zone.Store.remove_zone/1 so zones can be unloaded from a running system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 /bench
 /Mnesia*
 .DS_Store
+.elixir_ls
+.tool-versions

--- a/lib/carmen/zone/zone_store.ex
+++ b/lib/carmen/zone/zone_store.ex
@@ -12,6 +12,14 @@ defmodule Carmen.Zone.Store do
     )
   end
 
+  def remove_zone(id) do
+    :poolboy.transaction(
+      @pool_name,
+      fn pid -> GenServer.call(pid, {:remove_zone, id}, 30_000) end,
+      :infinity
+    )
+  end
+
   def get_zone(id) do
     :poolboy.transaction(
       @pool_name,

--- a/lib/carmen/zone/zone_store_worker.ex
+++ b/lib/carmen/zone/zone_store_worker.ex
@@ -27,6 +27,21 @@ defmodule Carmen.Zone.Worker do
     {:reply, id, grid}
   end
 
+  def handle_call({:remove_zone, id}, _from, grid) do
+    {:atomic, _} =
+      Mnesia.transaction(fn ->
+        case get_zone_by_id(id) do
+          nil -> nil
+          old_shape -> delete_shape_from_grid(id, old_shape, grid)
+        end
+
+        Mnesia.delete({Zone, id})
+        Mnesia.delete({ZoneEnv, id})
+      end)
+
+    {:reply, :ok, grid}
+  end
+
   def handle_call({:get_zone, id}, _from, grid) do
     case Mnesia.dirty_read({Zone, id}) do
       [{Zone, ^id, shape, _meta}] -> {:reply, shape, grid}

--- a/test/zone_store_test.exs
+++ b/test/zone_store_test.exs
@@ -101,6 +101,11 @@ defmodule Carmen.ZoneStoreTest do
     assert Store.get_zone(UUID.uuid4()) == nil
   end
 
+  test "put, delete, and get shape", %{id1: id} do
+    assert :ok = Store.remove_zone(id)
+    assert Store.get_zone(id) == nil
+  end
+
   test "intersecting zones for a given point", %{id1: id1, id2: id2} do
     assert Store.intersections(@in_shape1) == [id1]
     assert Store.intersections(@in_both) |> Enum.sort() == [id1, id2] |> Enum.sort()


### PR DESCRIPTION
Usage:
```
id = Store.put_zone(%Geo.Polygon{})
:ok = Store.remove_zone(id)
```